### PR TITLE
Fix extra video parsing and improve layout

### DIFF
--- a/src/hooks/usePeriods.ts
+++ b/src/hooks/usePeriods.ts
@@ -20,9 +20,10 @@ interface Period {
   quiz: Quiz | null;
 }
 
-const clean = (s = '') => s.replace(/[\[\]"]/g, '').trim();
-const splitMulti = (s: string) =>
-  clean(s).split(/[,;\n]/).map(t => t.trim()).filter(Boolean);
+const sanitize  = (s = '') => s.replace(/[\[\]"]/g, '').trim();
+const parseList = (s?: string) =>
+  sanitize(s).split(/[,;\n]/).map(t => t.trim()).filter(Boolean);
+const parseVideo = (s?: string) => sanitize(s);
 
 const parseQuiz = (s?: string): Quiz | null => {
   try {
@@ -58,16 +59,16 @@ export function usePeriods(): Period[] {
             p.video = val;
             break;
           case 'concepts':
-            p.concepts = splitMulti(val);
+            p.concepts = parseList(val);
             break;
           case 'authors':
-            p.authors = splitMulti(val);
+            p.authors = parseList(val);
             break;
           case 'coreRead':
             p.coreRead = val;
             break;
           case 'extraVideo':
-            p.extraVideo = val;
+            p.extraVideo = parseVideo(val);
             break;
           case 'quiz':
             p.quiz = parseQuiz(val);

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -2,7 +2,9 @@ import Sidebar from '../components/Sidebar';
 
 export default function DefaultLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="grid lg:grid-cols-[220px_1fr] gap-6 p-4">
+    <div
+      className="grid lg:grid-cols-[220px_minmax(0,1fr)]
+                 gap-10 px-4 lg:px-8">
       <Sidebar />
       {children}
     </div>

--- a/src/pages/PeriodPage.tsx
+++ b/src/pages/PeriodPage.tsx
@@ -7,7 +7,9 @@ export default function PeriodPage() {
   if (!period) return <p>Not found</p>;
 
   return (
-    <article className="max-w-prose mx-auto space-y-8 py-8">
+    <article
+      className="w-full max-w-3xl space-y-10
+                 px-4 sm:px-6 lg:px-0 py-8 mx-auto">
       <h1 className="text-3xl font-bold">{period.title}</h1>
 
       {period.concepts?.length && (


### PR DESCRIPTION
## Summary
- sanitize extraVideo field properly
- widen article content with responsive padding
- expand layout column and add padding

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c126d21e0832c980f8eebe4a5cfbf