### PR TITLE
refactor(timeline): topology tree fixes drag/delete/edit cascades (B1–B15)

### DIFF
--- a/src/pages/Timeline.tsx
+++ b/src/pages/Timeline.tsx
@@ -238,19 +238,19 @@ export default function Timeline() {
   const resetTransientTimelineUi = useCallback(() => {
     formHook.clearForm();
     setSelectedId(null);
-    branchHook.setSelectedBranchX(null);
+    branchHook.setSelectedBranchId(null);
     birthHook.setBirthSelected(false);
     setPeriodBoundaryModal(null);
     setShowBulkCreator(false);
     biographyImportResetRef.current();
     resetHistory();
-  }, [birthHook.setBirthSelected, branchHook.setSelectedBranchX, formHook.clearForm, resetHistory]);
+  }, [birthHook.setBirthSelected, branchHook.setSelectedBranchId, formHook.clearForm, resetHistory]);
 
   // Auto-pickup sphere when selecting branch
   useEffect(() => {
     if (formHook.formEventId !== null) return;
-    if (branchHook.selectedBranchX !== null) {
-      const selectedEdge = edges.find((e) => e.x === branchHook.selectedBranchX);
+    if (branchHook.selectedBranchId !== null) {
+      const selectedEdge = edges.find((e) => e.id === branchHook.selectedBranchId);
       if (selectedEdge) {
         const originNode = nodes.find((n) => n.id === selectedEdge.nodeId);
         if (originNode && originNode.sphere) {
@@ -258,7 +258,7 @@ export default function Timeline() {
         }
       }
     }
-  }, [branchHook.selectedBranchX, edges, nodes, formHook.formEventId]);
+  }, [branchHook.selectedBranchId, edges, nodes, formHook.formEventId]);
 
   useEffect(() => {
     resetTransientTimelineUi();
@@ -341,7 +341,7 @@ export default function Timeline() {
     onEscape: () => {
       formHook.clearForm();
       setSelectedId(null);
-      branchHook.setSelectedBranchX(null);
+      branchHook.setSelectedBranchId(null);
       birthHook.setBirthSelected(false);
     },
   });
@@ -352,13 +352,13 @@ export default function Timeline() {
     setPeriodBoundaryModal({ periodIndex });
   };
 
-  const handleSelectBranch = (x: number) => {
-    branchHook.handleSelectBranch(x);
+  const handleSelectBranch = (edgeId: string) => {
+    branchHook.handleSelectBranch(edgeId);
     birthHook.setBirthSelected(false);
   };
 
   const handleClearSelection = () => {
-    branchHook.setSelectedBranchX(null);
+    branchHook.setSelectedBranchId(null);
     birthHook.setBirthSelected(false);
   };
 
@@ -403,7 +403,7 @@ export default function Timeline() {
         isDecision: formHook.formEventIsDecision,
         icon: formHook.formEventIcon,
       },
-      branchHook.selectedBranchX
+      branchHook.selectedBranchId
     );
   };
 
@@ -471,7 +471,7 @@ export default function Timeline() {
           edges={edges}
           selectedPeriodization={selectedPeriodization}
           selectedId={selectedId}
-          selectedBranchX={branchHook.selectedBranchX}
+          selectedBranchId={branchHook.selectedBranchId}
           draggingNodeId={dragDropHook.draggingNodeId}
           birthSelected={birthHook.birthSelected}
           birthBaseYear={birthHook.birthBaseYear}
@@ -529,7 +529,7 @@ export default function Timeline() {
           onClearForm={formHook.clearForm}
           onDeleteEvent={crudHook.deleteNode}
           createNote={createNote}
-          selectedBranchX={branchHook.selectedBranchX}
+          selectedBranchId={branchHook.selectedBranchId}
           selectedEdge={branchHook.selectedEdge}
           branchYears={branchHook.branchYears}
           onBranchYearsChange={branchHook.setBranchYears}
@@ -565,7 +565,6 @@ export default function Timeline() {
             onCreate={crudHook.handleBulkCreate}
             onExtendBranch={branchHook.handleExtendBranchForBulk}
             ageMax={ageMax}
-            selectedBranchX={branchHook.selectedBranchX}
             selectedEdge={branchHook.selectedEdge}
             branchSphere={branchHook.selectedEdge ? (() => {
               const originNode = nodes.find((n) => n.id === branchHook.selectedEdge!.nodeId);

--- a/src/pages/TimelineAutomation.tsx
+++ b/src/pages/TimelineAutomation.tsx
@@ -215,7 +215,7 @@ export default function TimelineAutomation() {
               edges={timeline.edges}
               selectedPeriodization={timeline.selectedPeriodization ?? null}
               selectedId={null}
-              selectedBranchX={null}
+              selectedBranchId={null}
               draggingNodeId={null}
               birthSelected={false}
               birthBaseYear={birthBaseYear}

--- a/src/pages/timeline/components/BulkEventCreator.tsx
+++ b/src/pages/timeline/components/BulkEventCreator.tsx
@@ -8,7 +8,6 @@ interface BulkEventCreatorProps {
   onCreate: (events: Omit<NodeT, 'id'>[]) => void;
   onExtendBranch?: (newEndAge: number) => void;
   ageMax: number;
-  selectedBranchX: number | null;
   selectedEdge?: EdgeT | null;
   branchSphere?: Sphere;
 }
@@ -22,11 +21,12 @@ export function BulkEventCreator({
   onCreate,
   onExtendBranch,
   ageMax,
-  selectedBranchX,
   selectedEdge,
   branchSphere
 }: BulkEventCreatorProps) {
   const [inputText, setInputText] = useState('');
+  // Place new events on the selected branch's x (or main line otherwise).
+  const branchX = selectedEdge?.x ?? null;
 
   const minAge = selectedEdge ? selectedEdge.startAge : 0;
   const maxAge = selectedEdge ? selectedEdge.endAge : ageMax;
@@ -70,8 +70,8 @@ export function BulkEventCreator({
     const events: Omit<NodeT, 'id'>[] = validEvents.map((e) => ({
       age: e.age!,
       label: e.label!,
-      x: selectedBranchX ?? LINE_X_POSITION,
-      parentX: selectedBranchX ?? undefined,
+      x: branchX ?? LINE_X_POSITION,
+      parentX: branchX ?? undefined,
       notes: '',
       sphere: branchSphere, // Автоматически устанавливаем сферу от ветки
       isDecision: false,
@@ -95,8 +95,8 @@ export function BulkEventCreator({
       .map((e) => ({
         age: e.age!,
         label: e.label!,
-        x: selectedBranchX ?? LINE_X_POSITION,
-        parentX: selectedBranchX ?? undefined,
+        x: branchX ?? LINE_X_POSITION,
+        parentX: branchX ?? undefined,
         notes: '',
         sphere: branchSphere,
         isDecision: false,

--- a/src/pages/timeline/components/TimelineCanvas.tsx
+++ b/src/pages/timeline/components/TimelineCanvas.tsx
@@ -23,7 +23,7 @@ interface TimelineCanvasProps {
   onNodeClick: (nodeId: string) => void;
   onNodeDragStart: (event: PointerEvent, nodeId: string) => void;
   onPeriodBoundaryClick: (periodIndex: number) => void;
-  onSelectBranch: (x: number) => void;
+  onSelectBranch: (edgeId: string) => void;
   onClearSelection: () => void;
   onSelectBirth: () => void;
   worldWidth: number;
@@ -34,7 +34,7 @@ interface TimelineCanvasProps {
   edges: EdgeT[];
   selectedPeriodization: string | null;
   selectedId: string | null;
-  selectedBranchX: number | null;
+  selectedBranchId: string | null;
   draggingNodeId: string | null;
   birthSelected: boolean;
   birthBaseYear: number | null;
@@ -65,7 +65,7 @@ export const TimelineCanvas = memo(function TimelineCanvas(props: TimelineCanvas
     edges,
     selectedPeriodization,
     selectedId,
-    selectedBranchX,
+    selectedBranchId,
     draggingNodeId,
     birthSelected,
     birthBaseYear,
@@ -181,7 +181,7 @@ export const TimelineCanvas = memo(function TimelineCanvas(props: TimelineCanvas
             x2={LINE_X_POSITION}
             y2={worldHeight - currentAge * YEAR_PX}
             stroke="#93c5fd"
-            strokeWidth={selectedBranchX === null ? 16 : 11}
+            strokeWidth={selectedBranchId === null ? 16 : 11}
             strokeLinecap="round"
             onClick={(e) => {
               e.stopPropagation();
@@ -197,7 +197,7 @@ export const TimelineCanvas = memo(function TimelineCanvas(props: TimelineCanvas
             x2={LINE_X_POSITION}
             y2={worldHeight - ageMax * YEAR_PX}
             stroke="#cbd5e1"
-            strokeWidth={selectedBranchX === null ? 16 : 11}
+            strokeWidth={selectedBranchId === null ? 16 : 11}
             strokeLinecap="round"
             strokeDasharray="10 5"
             onClick={(e) => {
@@ -267,7 +267,7 @@ export const TimelineCanvas = memo(function TimelineCanvas(props: TimelineCanvas
           </g>
 
           {validEdges.map((edge) => {
-              const isSelected = selectedBranchX === edge.x;
+              const isSelected = selectedBranchId === edge.id;
               const originNode = validNodes.find((node) => node.id === edge.nodeId);
               const originX = originNode?.x ?? LINE_X_POSITION;
               const connectorY = worldHeight - edge.startAge * YEAR_PX;
@@ -291,7 +291,7 @@ export const TimelineCanvas = memo(function TimelineCanvas(props: TimelineCanvas
                         strokeLinecap="round"
                         onClick={(e) => {
                           e.stopPropagation();
-                          onSelectBranch(edge.x);
+                          onSelectBranch(edge.id);
                         }}
                         className="cursor-pointer"
                         style={{ cursor: 'pointer' }}
@@ -319,7 +319,7 @@ export const TimelineCanvas = memo(function TimelineCanvas(props: TimelineCanvas
                     strokeLinecap="round"
                     onClick={(e) => {
                       e.stopPropagation();
-                      onSelectBranch(edge.x);
+                      onSelectBranch(edge.id);
                     }}
                     className="cursor-pointer"
                     style={{ cursor: 'pointer' }}
@@ -347,9 +347,14 @@ export const TimelineCanvas = memo(function TimelineCanvas(props: TimelineCanvas
               const x = node.x ?? LINE_X_POSITION;
               const iconMeta = node.iconId ? EVENT_ICON_MAP[node.iconId] : null;
               const iconSize = adaptiveRadius * 2;
+              // Highlight events sitting on the currently selected branch.
+              // selectedBranchId resolves to an edge.x via the edges list.
+              const selectedBranchEdgeX = selectedBranchId
+                ? validEdges.find((e) => e.id === selectedBranchId)?.x ?? null
+                : null;
               const isBranchSelected =
-                selectedBranchX !== null &&
-                x === selectedBranchX &&
+                selectedBranchEdgeX !== null &&
+                x === selectedBranchEdgeX &&
                 x !== LINE_X_POSITION;
               const parentLineX = node.parentX ?? LINE_X_POSITION;
               const labelOnLeft = x < LINE_X_POSITION;

--- a/src/pages/timeline/components/TimelineRightPanel.tsx
+++ b/src/pages/timeline/components/TimelineRightPanel.tsx
@@ -45,7 +45,7 @@ interface TimelineRightPanelProps {
     topicId: string | null,
     topicTitle: string | null
   ) => Promise<string>;
-  selectedBranchX: number | null;
+  selectedBranchId: string | null;
   selectedEdge: EdgeT | undefined;
   branchYears: string;
   onBranchYearsChange: (value: string) => void;
@@ -96,7 +96,7 @@ export function TimelineRightPanel(props: TimelineRightPanelProps) {
     onClearForm,
     onDeleteEvent,
     createNote,
-    selectedBranchX,
+    selectedBranchId,
     selectedEdge,
     branchYears,
     onBranchYearsChange,
@@ -199,7 +199,7 @@ export function TimelineRightPanel(props: TimelineRightPanelProps) {
           />
         )}
 
-        {(!selectedBranchX || formEventId) && (
+        {(!selectedBranchId || formEventId) && (
           <>
             <TimelineEventForm
               title={formEventId ? 'Редактировать событие' : 'Новое событие'}
@@ -240,7 +240,7 @@ export function TimelineRightPanel(props: TimelineRightPanelProps) {
         )}
 
 
-        {selectedBranchX && !formEventId && (
+        {selectedBranchId && !formEventId && (
           <>
             {selectedEdge && (
               <TimelineBranchEditor

--- a/src/pages/timeline/hooks/__tests__/useTimelineBranch.test.ts
+++ b/src/pages/timeline/hooks/__tests__/useTimelineBranch.test.ts
@@ -1,0 +1,208 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useTimelineBranch } from '../useTimelineBranch';
+import type { EdgeT, NodeT } from '../../types';
+
+global.alert = vi.fn();
+
+describe('useTimelineBranch', () => {
+  let setNodes: ReturnType<typeof vi.fn<(nodes: NodeT[]) => void>>;
+  let setEdges: ReturnType<typeof vi.fn<(edges: EdgeT[]) => void>>;
+  let onHistoryRecord: ReturnType<typeof vi.fn<(nodes?: NodeT[], edges?: EdgeT[]) => void>>;
+  let onClearForm: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    setNodes = vi.fn<(nodes: NodeT[]) => void>();
+    setEdges = vi.fn<(edges: EdgeT[]) => void>();
+    onHistoryRecord = vi.fn<(nodes?: NodeT[], edges?: EdgeT[]) => void>();
+    onClearForm = vi.fn<() => void>();
+    vi.clearAllMocks();
+  });
+
+  describe('extendBranch (B13)', () => {
+    it('refuses to create a branch that would extend past ageMax', () => {
+      const node: NodeT = {
+        id: 'n1',
+        age: 90,
+        x: 2100,
+        parentX: 2100,
+        label: 'Old',
+        isDecision: false,
+        sphere: 'career',
+      };
+      const { result } = renderHook(() =>
+        useTimelineBranch({
+          nodes: [node],
+          edges: [],
+          setNodes,
+          setEdges,
+          ageMax: 100,
+          onHistoryRecord,
+          onClearForm,
+        })
+      );
+
+      act(() => result.current.setBranchYears('30')); // 90 + 30 = 120 > 100
+      act(() => result.current.extendBranch(node));
+
+      expect(alert).toHaveBeenCalledWith(expect.stringContaining('не помещается'));
+      expect(setEdges).not.toHaveBeenCalled();
+    });
+
+    it('creates a branch that fits within ageMax', () => {
+      const node: NodeT = {
+        id: 'n1',
+        age: 70,
+        x: 2100,
+        parentX: 2100,
+        label: 'X',
+        isDecision: false,
+        sphere: 'career',
+      };
+      const { result } = renderHook(() =>
+        useTimelineBranch({
+          nodes: [node],
+          edges: [],
+          setNodes,
+          setEdges,
+          ageMax: 100,
+          onHistoryRecord,
+          onClearForm,
+        })
+      );
+
+      act(() => result.current.setBranchYears('20')); // 70 + 20 = 90 ≤ 100
+      act(() => result.current.extendBranch(node));
+
+      expect(setEdges).toHaveBeenCalled();
+      const edgesArg = setEdges.mock.calls[0]![0];
+      expect(edgesArg[0]).toMatchObject({ startAge: 70, endAge: 90, nodeId: 'n1' });
+    });
+  });
+
+  describe('updateBranchLength (B14)', () => {
+    it('refuses to shorten the branch past existing events on it', () => {
+      const origin: NodeT = {
+        id: 'origin',
+        age: 20,
+        x: 2000,
+        label: 'Origin',
+        isDecision: false,
+        sphere: 'career',
+      };
+      const branchEvent: NodeT = {
+        id: 'b',
+        age: 28,
+        x: 2100,
+        parentX: 2100,
+        label: 'Event on branch',
+        isDecision: false,
+        sphere: 'career',
+      };
+      const branch: EdgeT = {
+        id: 'e1',
+        x: 2100,
+        startAge: 20,
+        endAge: 30,
+        color: '#000',
+        nodeId: 'origin',
+      };
+
+      const { result } = renderHook(() =>
+        useTimelineBranch({
+          nodes: [origin, branchEvent],
+          edges: [branch],
+          setNodes,
+          setEdges,
+          ageMax: 100,
+          onHistoryRecord,
+          onClearForm,
+        })
+      );
+
+      act(() => result.current.setSelectedBranchX(2100));
+      act(() => result.current.setBranchYears('5')); // new endAge = 25, but b.age = 28
+      act(() => result.current.updateBranchLength());
+
+      expect(alert).toHaveBeenCalledWith(expect.stringContaining('за пределами'));
+      expect(setEdges).not.toHaveBeenCalled();
+    });
+
+    it('allows shortening that does not orphan any event', () => {
+      const origin: NodeT = {
+        id: 'origin',
+        age: 20,
+        x: 2000,
+        label: 'Origin',
+        isDecision: false,
+        sphere: 'career',
+      };
+      const branch: EdgeT = {
+        id: 'e1',
+        x: 2100,
+        startAge: 20,
+        endAge: 30,
+        color: '#000',
+        nodeId: 'origin',
+      };
+
+      const { result } = renderHook(() =>
+        useTimelineBranch({
+          nodes: [origin],
+          edges: [branch],
+          setNodes,
+          setEdges,
+          ageMax: 100,
+          onHistoryRecord,
+          onClearForm,
+        })
+      );
+
+      act(() => result.current.setSelectedBranchX(2100));
+      act(() => result.current.setBranchYears('5'));
+      act(() => result.current.updateBranchLength());
+
+      expect(setEdges).toHaveBeenCalled();
+      const edgesArg = setEdges.mock.calls[0]![0];
+      expect(edgesArg[0]).toMatchObject({ id: 'e1', endAge: 25 });
+    });
+
+    it('allows extending the branch (no events to orphan above current end)', () => {
+      const origin: NodeT = {
+        id: 'origin',
+        age: 20,
+        x: 2000,
+        label: 'Origin',
+        isDecision: false,
+        sphere: 'career',
+      };
+      const branch: EdgeT = {
+        id: 'e1',
+        x: 2100,
+        startAge: 20,
+        endAge: 30,
+        color: '#000',
+        nodeId: 'origin',
+      };
+
+      const { result } = renderHook(() =>
+        useTimelineBranch({
+          nodes: [origin],
+          edges: [branch],
+          setNodes,
+          setEdges,
+          ageMax: 100,
+          onHistoryRecord,
+          onClearForm,
+        })
+      );
+
+      act(() => result.current.setSelectedBranchX(2100));
+      act(() => result.current.setBranchYears('25')); // 20..45
+      act(() => result.current.updateBranchLength());
+
+      expect(setEdges).toHaveBeenCalled();
+      expect(setEdges.mock.calls[0]![0][0]).toMatchObject({ endAge: 45 });
+    });
+  });
+});

--- a/src/pages/timeline/hooks/__tests__/useTimelineBranch.test.ts
+++ b/src/pages/timeline/hooks/__tests__/useTimelineBranch.test.ts
@@ -49,6 +49,47 @@ describe('useTimelineBranch', () => {
       expect(setEdges).not.toHaveBeenCalled();
     });
 
+    it('B12: offsets a new branch when source event already sits on one', () => {
+      // Event b lives on existing branch e1 at x=2100. Creating a new
+      // branch from b should pick the next free x, not collide with e1.
+      const b: NodeT = {
+        id: 'b',
+        age: 25,
+        x: 2100,
+        parentX: 2100,
+        label: 'B',
+        isDecision: false,
+        sphere: 'career',
+      };
+      const existing: EdgeT = {
+        id: 'e1',
+        x: 2100,
+        startAge: 20,
+        endAge: 35,
+        color: '#000',
+        nodeId: 'origin',
+      };
+      const { result } = renderHook(() =>
+        useTimelineBranch({
+          nodes: [b],
+          edges: [existing],
+          setNodes,
+          setEdges,
+          ageMax: 100,
+          onHistoryRecord,
+          onClearForm,
+        })
+      );
+
+      act(() => result.current.setBranchYears('5'));
+      act(() => result.current.extendBranch(b));
+
+      const edgesArg = setEdges.mock.calls[0]![0];
+      const newBranch = edgesArg.find((edge: EdgeT) => edge.id !== 'e1')!;
+      expect(newBranch.x).toBeGreaterThan(2100); // shifted away from existing
+      expect(newBranch.nodeId).toBe('b');
+    });
+
     it('creates a branch that fits within ageMax', () => {
       const node: NodeT = {
         id: 'n1',

--- a/src/pages/timeline/hooks/__tests__/useTimelineBranch.test.ts
+++ b/src/pages/timeline/hooks/__tests__/useTimelineBranch.test.ts
@@ -161,7 +161,7 @@ describe('useTimelineBranch', () => {
         })
       );
 
-      act(() => result.current.setSelectedBranchX(2100));
+      act(() => result.current.setSelectedBranchId("e1"));
       act(() => result.current.setBranchYears('5')); // new endAge = 25, but b.age = 28
       act(() => result.current.updateBranchLength());
 
@@ -199,7 +199,7 @@ describe('useTimelineBranch', () => {
         })
       );
 
-      act(() => result.current.setSelectedBranchX(2100));
+      act(() => result.current.setSelectedBranchId("e1"));
       act(() => result.current.setBranchYears('5'));
       act(() => result.current.updateBranchLength());
 
@@ -238,7 +238,7 @@ describe('useTimelineBranch', () => {
         })
       );
 
-      act(() => result.current.setSelectedBranchX(2100));
+      act(() => result.current.setSelectedBranchId("e1"));
       act(() => result.current.setBranchYears('25')); // 20..45
       act(() => result.current.updateBranchLength());
 

--- a/src/pages/timeline/hooks/__tests__/useTimelineCRUD.test.ts
+++ b/src/pages/timeline/hooks/__tests__/useTimelineCRUD.test.ts
@@ -330,6 +330,85 @@ describe('useTimelineCRUD', () => {
       expect(setEdges).not.toHaveBeenCalled();
     });
 
+    it('B11: rejects an edit that pushes a branch event outside the branch range', () => {
+      const nodesOnBranch: NodeT[] = [
+        { id: 'b', age: 25, x: 2100, parentX: 2100, label: 'Event', isDecision: false, sphere: 'career' },
+      ];
+      const branchEdge: EdgeT[] = [
+        { id: 'e1', x: 2100, startAge: 20, endAge: 30, color: '#000', nodeId: 'origin' },
+      ];
+
+      const { result } = renderHook(() =>
+        useTimelineCRUD({
+          nodes: nodesOnBranch,
+          edges: branchEdge,
+          ageMax: 100,
+          setNodes,
+          setEdges,
+          onHistoryRecord,
+          onClearForm,
+          onSetSelectedId,
+        })
+      );
+
+      act(() => {
+        result.current.handleFormSubmit(
+          {
+            id: 'b',
+            age: '50', // outside [20, 30]
+            label: 'Event',
+            notes: '',
+            sphere: 'career',
+            isDecision: false,
+            icon: null,
+          },
+          null
+        );
+      });
+
+      expect(alert).toHaveBeenCalledWith(expect.stringContaining('вне диапазона ветки'));
+      expect(setNodes).not.toHaveBeenCalled();
+    });
+
+    it('B11: allows an edit that stays within the branch range', () => {
+      const nodesOnBranch: NodeT[] = [
+        { id: 'b', age: 25, x: 2100, parentX: 2100, label: 'Event', isDecision: false, sphere: 'career' },
+      ];
+      const branchEdge: EdgeT[] = [
+        { id: 'e1', x: 2100, startAge: 20, endAge: 30, color: '#000', nodeId: 'origin' },
+      ];
+
+      const { result } = renderHook(() =>
+        useTimelineCRUD({
+          nodes: nodesOnBranch,
+          edges: branchEdge,
+          ageMax: 100,
+          setNodes,
+          setEdges,
+          onHistoryRecord,
+          onClearForm,
+          onSetSelectedId,
+        })
+      );
+
+      act(() => {
+        result.current.handleFormSubmit(
+          {
+            id: 'b',
+            age: '28', // inside [20, 30]
+            label: 'Event',
+            notes: '',
+            sphere: 'career',
+            isDecision: false,
+            icon: null,
+          },
+          null
+        );
+      });
+
+      expect(setNodes).toHaveBeenCalled();
+    });
+
     it('does not call setEdges when age is unchanged', () => {
       const nodesWithOrigin: NodeT[] = [
         { id: 'origin', age: 20, x: 2000, label: 'Origin', isDecision: false, sphere: 'career' },

--- a/src/pages/timeline/hooks/__tests__/useTimelineCRUD.test.ts
+++ b/src/pages/timeline/hooks/__tests__/useTimelineCRUD.test.ts
@@ -209,6 +209,165 @@ describe('useTimelineCRUD', () => {
       expect(alert).toHaveBeenCalledWith('Возраст должен быть от 0 до 100 лет');
       expect(setNodes).not.toHaveBeenCalled();
     });
+
+    it('B10: editing the age of a branch origin slides edge.startAge/endAge by the same delta', () => {
+      const nodesWithOrigin: NodeT[] = [
+        { id: 'origin', age: 20, x: 2000, label: 'Origin', isDecision: false, sphere: 'career' },
+      ];
+      const edgesFromOrigin: EdgeT[] = [
+        { id: 'e1', x: 2100, startAge: 20, endAge: 30, color: '#000', nodeId: 'origin' },
+      ];
+
+      const { result } = renderHook(() =>
+        useTimelineCRUD({
+          nodes: nodesWithOrigin,
+          edges: edgesFromOrigin,
+          ageMax: 100,
+          setNodes,
+          setEdges,
+          onHistoryRecord,
+          onClearForm,
+          onSetSelectedId,
+        })
+      );
+
+      act(() => {
+        result.current.handleFormSubmit(
+          {
+            id: 'origin',
+            age: '25',
+            label: 'Origin',
+            notes: '',
+            sphere: 'career',
+            isDecision: false,
+            icon: null,
+          },
+          null
+        );
+      });
+
+      expect(setEdges).toHaveBeenCalledTimes(1);
+      const edgesArg = setEdges.mock.calls[0]![0];
+      expect(edgesArg[0]).toMatchObject({ id: 'e1', startAge: 25, endAge: 35 });
+    });
+
+    it('B10: clamps endAge to ageMax when origin moves close to ageMax', () => {
+      const nodesWithOrigin: NodeT[] = [
+        { id: 'origin', age: 90, x: 2000, label: 'Old', isDecision: false, sphere: 'career' },
+      ];
+      const edgesFromOrigin: EdgeT[] = [
+        { id: 'e1', x: 2100, startAge: 90, endAge: 95, color: '#000', nodeId: 'origin' },
+      ];
+
+      const { result } = renderHook(() =>
+        useTimelineCRUD({
+          nodes: nodesWithOrigin,
+          edges: edgesFromOrigin,
+          ageMax: 100,
+          setNodes,
+          setEdges,
+          onHistoryRecord,
+          onClearForm,
+          onSetSelectedId,
+        })
+      );
+
+      act(() => {
+        result.current.handleFormSubmit(
+          {
+            id: 'origin',
+            age: '98',
+            label: 'Old',
+            notes: '',
+            sphere: 'career',
+            isDecision: false,
+            icon: null,
+          },
+          null
+        );
+      });
+
+      const edgesArg = setEdges.mock.calls[0]![0];
+      expect(edgesArg[0]).toMatchObject({ id: 'e1', startAge: 98, endAge: 100 }); // clamped
+    });
+
+    it('does NOT touch edges when editing an event that is not a branch origin', () => {
+      const nodesWithChild: NodeT[] = [
+        { id: 'child', age: 25, x: 2100, parentX: 2100, label: 'Child', isDecision: false, sphere: 'career' },
+      ];
+      const edgesUnrelated: EdgeT[] = [
+        { id: 'e1', x: 2100, startAge: 20, endAge: 30, color: '#000', nodeId: 'origin' },
+      ];
+
+      const { result } = renderHook(() =>
+        useTimelineCRUD({
+          nodes: nodesWithChild,
+          edges: edgesUnrelated,
+          ageMax: 100,
+          setNodes,
+          setEdges,
+          onHistoryRecord,
+          onClearForm,
+          onSetSelectedId,
+        })
+      );
+
+      act(() => {
+        result.current.handleFormSubmit(
+          {
+            id: 'child',
+            age: '27',
+            label: 'Child',
+            notes: '',
+            sphere: 'career',
+            isDecision: false,
+            icon: null,
+          },
+          null
+        );
+      });
+
+      expect(setEdges).not.toHaveBeenCalled();
+    });
+
+    it('does not call setEdges when age is unchanged', () => {
+      const nodesWithOrigin: NodeT[] = [
+        { id: 'origin', age: 20, x: 2000, label: 'Origin', isDecision: false, sphere: 'career' },
+      ];
+      const edgesFromOrigin: EdgeT[] = [
+        { id: 'e1', x: 2100, startAge: 20, endAge: 30, color: '#000', nodeId: 'origin' },
+      ];
+
+      const { result } = renderHook(() =>
+        useTimelineCRUD({
+          nodes: nodesWithOrigin,
+          edges: edgesFromOrigin,
+          ageMax: 100,
+          setNodes,
+          setEdges,
+          onHistoryRecord,
+          onClearForm,
+          onSetSelectedId,
+        })
+      );
+
+      act(() => {
+        result.current.handleFormSubmit(
+          {
+            id: 'origin',
+            age: '20',
+            label: 'Renamed',
+            notes: '',
+            sphere: 'career',
+            isDecision: false,
+            icon: null,
+          },
+          null
+        );
+      });
+
+      expect(setEdges).not.toHaveBeenCalled();
+    });
   });
 
   describe('deleteNode', () => {

--- a/src/pages/timeline/hooks/useTimelineBranch.ts
+++ b/src/pages/timeline/hooks/useTimelineBranch.ts
@@ -26,11 +26,13 @@ export function useTimelineBranch({
   onClearForm,
 }: UseTimelineBranchOptions) {
   const [branchYears, setBranchYears] = useState<string>('5');
-  const [selectedBranchX, setSelectedBranchX] = useState<number | null>(null);
+  // B15: identify the current selection by edge.id, not by x — two
+  // branches can legitimately share an x-coord (legacy data) and id
+  // is the actual primary key.
+  const [selectedBranchId, setSelectedBranchId] = useState<string | null>(null);
 
-  // Get currently selected edge
-  const selectedEdge = selectedBranchX !== null
-    ? edges.find((e) => e.x === selectedBranchX) ?? null
+  const selectedEdge = selectedBranchId
+    ? edges.find((e) => e.id === selectedBranchId) ?? null
     : null;
 
   /**
@@ -98,7 +100,7 @@ export function useTimelineBranch({
 
       // Clear form and deselect
       onClearForm?.();
-      setSelectedBranchX(null);
+      setSelectedBranchId(null);
     },
     [branchYears, edges, nodes, setEdges, onHistoryRecord, onClearForm]
   );
@@ -172,7 +174,7 @@ export function useTimelineBranch({
 
     setNodes(updatedNodes);
     setEdges(updatedEdges);
-    setSelectedBranchX(null); // Deselect
+    setSelectedBranchId(null); // Deselect
     onHistoryRecord?.(updatedNodes, updatedEdges);
   }, [selectedEdge, nodes, edges, setNodes, setEdges, onHistoryRecord]);
 
@@ -193,28 +195,28 @@ export function useTimelineBranch({
   );
 
   /**
-   * Select a branch for editing
+   * Select a branch for editing — by edge.id, the primary key.
    */
-  const handleSelectBranch = useCallback((x: number) => {
-    setSelectedBranchX(x);
+  const handleSelectBranch = useCallback((edgeId: string) => {
+    setSelectedBranchId(edgeId);
   }, []);
 
   /**
    * Deselect branch
    */
   const handleHideBranchEditor = useCallback(() => {
-    setSelectedBranchX(null);
+    setSelectedBranchId(null);
   }, []);
 
   return {
     // State
     branchYears,
-    selectedBranchX,
+    selectedBranchId,
     selectedEdge,
 
     // Setters
     setBranchYears,
-    setSelectedBranchX,
+    setSelectedBranchId,
 
     // Handlers
     extendBranch,

--- a/src/pages/timeline/hooks/useTimelineBranch.ts
+++ b/src/pages/timeline/hooks/useTimelineBranch.ts
@@ -62,12 +62,22 @@ export function useTimelineBranch({
         return;
       }
 
+      // B13: clamp endAge to ageMax — отказ вместо тихого создания
+      // ветки за пределами холста.
+      const proposedEndAge = selectedNode.age + years;
+      if (proposedEndAge > ageMax) {
+        alert(
+          `Ветка не помещается на холсте. Максимальная длина — ${ageMax - selectedNode.age} лет (до ${ageMax}-летия).`
+        );
+        return;
+      }
+
       const meta = SPHERE_META[selectedNode.sphere];
       const edge: EdgeT = {
         id: crypto.randomUUID(),
         x: nodeX,
         startAge: selectedNode.age,
-        endAge: selectedNode.age + years,
+        endAge: proposedEndAge,
         color: meta.color,
         nodeId: selectedNode.id,
       };
@@ -101,6 +111,25 @@ export function useTimelineBranch({
     if (newEndAge > ageMax) {
       alert(`Максимальный возраст: ${ageMax} лет`);
       return;
+    }
+
+    // B14: refuse to shorten the branch past events that already live
+    // on it — those events would silently orphan above the new endAge.
+    if (newEndAge < selectedEdge.endAge) {
+      const eventsBeyond = nodes.filter(
+        (n) => n.parentX === selectedEdge.x && n.age > newEndAge
+      );
+      if (eventsBeyond.length > 0) {
+        const sample = eventsBeyond
+          .slice(0, 3)
+          .map((n) => `«${n.label}» (${n.age} лет)`)
+          .join(', ');
+        const more = eventsBeyond.length > 3 ? ` и ещё ${eventsBeyond.length - 3}` : '';
+        alert(
+          `На ветке есть события за пределами новой длины: ${sample}${more}. Сначала перенесите их или удалите.`
+        );
+        return;
+      }
     }
 
     // Update branch

--- a/src/pages/timeline/hooks/useTimelineBranch.ts
+++ b/src/pages/timeline/hooks/useTimelineBranch.ts
@@ -72,10 +72,20 @@ export function useTimelineBranch({
         return;
       }
 
+      // B12: if the source event already sits on a branch, its x
+      // collides with the existing branch — offset the new branch
+      // to the nearest free x so the two don't visually overlap and
+      // selection-by-x in the UI doesn't get confused.
+      let proposedBranchX = nodeX;
+      const OFFSET_STEP = 100;
+      while (edges.some((e) => e.x === proposedBranchX)) {
+        proposedBranchX += OFFSET_STEP;
+      }
+
       const meta = SPHERE_META[selectedNode.sphere];
       const edge: EdgeT = {
         id: crypto.randomUUID(),
-        x: nodeX,
+        x: proposedBranchX,
         startAge: selectedNode.age,
         endAge: proposedEndAge,
         color: meta.color,

--- a/src/pages/timeline/hooks/useTimelineBranch.ts
+++ b/src/pages/timeline/hooks/useTimelineBranch.ts
@@ -1,5 +1,6 @@
 import { useState, useCallback, useEffect } from 'react';
 import { LINE_X_POSITION, SPHERE_META } from '../constants';
+import { applyBranchDeletionToFlat } from '../utils/timelineTree';
 import type { NodeT, EdgeT } from '../types';
 
 interface UseTimelineBranchOptions {
@@ -111,7 +112,10 @@ export function useTimelineBranch({
   }, [selectedEdge, branchYears, ageMax, edges, nodes, setEdges, onHistoryRecord]);
 
   /**
-   * Delete branch and move events to parent line
+   * Delete branch and migrate every event on it (with its grand-branches)
+   * to the parent line. The actual topology walk lives in
+   * applyBranchDeletionToFlat — fixes B8 by also moving node.x, not just
+   * parentX, so migrated events end up on the line and not in midair.
    */
   const deleteBranch = useCallback(() => {
     if (!selectedEdge) return;
@@ -121,23 +125,11 @@ export function useTimelineBranch({
     );
     if (!confirmed) return;
 
-    // Find parent line of the branch being deleted
-    const originNode = nodes.find((n) => n.id === selectedEdge.nodeId);
-    const branchParentX = originNode?.parentX ?? LINE_X_POSITION;
-
-    // Update parentX for all events on this branch
-    const updatedNodes = nodes.map((node) => {
-      if (node.parentX === selectedEdge.x) {
-        return {
-          ...node,
-          parentX: branchParentX === LINE_X_POSITION ? undefined : branchParentX,
-        };
-      }
-      return node;
-    });
-
-    // Delete branch
-    const updatedEdges = edges.filter((e) => e.id !== selectedEdge.id);
+    const { nodes: updatedNodes, edges: updatedEdges } = applyBranchDeletionToFlat(
+      nodes,
+      edges,
+      selectedEdge.id
+    );
 
     setNodes(updatedNodes);
     setEdges(updatedEdges);

--- a/src/pages/timeline/hooks/useTimelineCRUD.ts
+++ b/src/pages/timeline/hooks/useTimelineCRUD.ts
@@ -60,6 +60,8 @@ export function useTimelineCRUD({
 
       if (formData.id) {
         // Edit existing event
+        const original = nodes.find((n) => n.id === formData.id);
+        const oldAge = original?.age;
         const updatedNodes = nodes.map((n) =>
           n.id === formData.id
             ? {
@@ -75,8 +77,30 @@ export function useTimelineCRUD({
               }
             : n
         );
+
+        // B10: if the edited event is the origin of one or more branches,
+        // slide each branch's age window by the same delta so the branch
+        // stays attached to its origin event. Length is preserved.
+        const ageChanged = oldAge !== undefined && oldAge !== parsedAge;
+        let updatedEdges = edges;
+        if (ageChanged) {
+          const deltaAge = parsedAge - oldAge!;
+          let mutated = false;
+          const next = edges.map((e) => {
+            if (e.nodeId !== formData.id) return e;
+            mutated = true;
+            const newStart = e.startAge + deltaAge;
+            const newEnd = Math.min(e.endAge + deltaAge, ageMax);
+            return { ...e, startAge: newStart, endAge: newEnd };
+          });
+          if (mutated) {
+            updatedEdges = next;
+            setEdges(updatedEdges);
+          }
+        }
+
         setNodes(updatedNodes);
-        onHistoryRecord?.(updatedNodes, edges);
+        onHistoryRecord?.(updatedNodes, updatedEdges);
       } else {
         // Add new event
         let eventX = LINE_X_POSITION;

--- a/src/pages/timeline/hooks/useTimelineCRUD.ts
+++ b/src/pages/timeline/hooks/useTimelineCRUD.ts
@@ -62,6 +62,26 @@ export function useTimelineCRUD({
         // Edit existing event
         const original = nodes.find((n) => n.id === formData.id);
         const oldAge = original?.age;
+
+        // B11: if the edited event lives on a branch, the new age must
+        // stay within that branch's age window — otherwise it would
+        // visually orphan above/below the line that anchors it.
+        if (
+          original &&
+          original.parentX !== undefined &&
+          original.parentX !== LINE_X_POSITION
+        ) {
+          const parentBranch = edges.find((e) => e.x === original.parentX);
+          if (
+            parentBranch &&
+            (parsedAge < parentBranch.startAge || parsedAge > parentBranch.endAge)
+          ) {
+            alert(
+              `Возраст ${parsedAge} вне диапазона ветки (${parentBranch.startAge}–${parentBranch.endAge} лет). Сначала измените длину ветки или перенесите событие на главную линию.`
+            );
+            return;
+          }
+        }
         const updatedNodes = nodes.map((n) =>
           n.id === formData.id
             ? {

--- a/src/pages/timeline/hooks/useTimelineCRUD.ts
+++ b/src/pages/timeline/hooks/useTimelineCRUD.ts
@@ -44,7 +44,7 @@ export function useTimelineCRUD({
    * Create or update an event
    */
   const handleFormSubmit = useCallback(
-    (formData: FormEventData, selectedBranchX: number | null) => {
+    (formData: FormEventData, selectedBranchId: string | null) => {
       if (!formData.label.trim()) return;
 
       if (!formData.age.trim()) {
@@ -124,42 +124,27 @@ export function useTimelineCRUD({
       } else {
         // Add new event
         let eventX = LINE_X_POSITION;
+        let eventParentX: number | undefined = undefined;
         let eventSphere = formData.sphere;
 
-        // If branch is selected, check if age falls within its range
-        if (selectedBranchX !== null) {
-          // Find edge with matching X that covers the specified age
-          const selectedEdge = edges.find(
-            (e) => e.x === selectedBranchX && parsedAge >= e.startAge && parsedAge <= e.endAge
-          );
-
+        if (selectedBranchId !== null) {
+          const selectedEdge = edges.find((e) => e.id === selectedBranchId);
           if (selectedEdge) {
-            // Age falls within branch range
-            eventX = selectedBranchX;
-
-            // Take sphere from branch origin node (always, if not manually specified)
+            const inRange = parsedAge >= selectedEdge.startAge && parsedAge <= selectedEdge.endAge;
+            if (inRange) {
+              eventX = selectedEdge.x;
+              eventParentX = selectedEdge.x;
+            } else {
+              alert(
+                `Возраст события (${parsedAge} лет) не попадает в диапазон выбранной ветки (${selectedEdge.startAge}-${selectedEdge.endAge} лет). Событие будет добавлено на основную линию жизни.`
+              );
+            }
+            // Auto-pickup sphere from branch origin even if age out of range.
             if (!eventSphere) {
               const originNode = nodes.find((n) => n.id === selectedEdge.nodeId);
               if (originNode && originNode.sphere) {
                 eventSphere = originNode.sphere;
               }
-            }
-          } else {
-            // If no exact match, try to find any branch with this X
-            // and take sphere from its origin node (for auto-pickup)
-            const anyEdgeAtX = edges.find((e) => e.x === selectedBranchX);
-            if (anyEdgeAtX) {
-              // Auto-pickup sphere even if age not in range
-              if (!eventSphere) {
-                const originNode = nodes.find((n) => n.id === anyEdgeAtX.nodeId);
-                if (originNode && originNode.sphere) {
-                  eventSphere = originNode.sphere;
-                }
-              }
-
-              alert(
-                `Возраст события (${parsedAge} лет) не попадает в диапазон выбранной ветки (${anyEdgeAtX.startAge}-${anyEdgeAtX.endAge} лет). Событие будет добавлено на основную линию жизни.`
-              );
             }
           }
         }
@@ -168,7 +153,7 @@ export function useTimelineCRUD({
           id: crypto.randomUUID(),
           age: parsedAge,
           x: eventX,
-          parentX: selectedBranchX ?? undefined, // Remember parent line
+          parentX: eventParentX, // Branch x (or undefined for main line)
           label: formData.label,
           notes: formData.notes,
           sphere: eventSphere,

--- a/src/pages/timeline/hooks/useTimelineCRUD.ts
+++ b/src/pages/timeline/hooks/useTimelineCRUD.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { LINE_X_POSITION } from '../constants';
 import { parseAge } from '../utils';
+import { buildTimelineTree, collectDescendantIds } from '../utils/timelineTree';
 import type { NodeT, EdgeT, Sphere, EventIconId } from '../types';
 
 interface UseTimelineCRUDOptions {
@@ -153,13 +154,28 @@ export function useTimelineCRUD({
   );
 
   /**
-   * Delete a node and all its branches
+   * Delete a node and the entire subtree rooted at it: every direct
+   * branch from the event, every event living on those branches, and
+   * (recursively) any branches and events those carry. Walks the
+   * topology tree so nothing is left orphaned in Firestore — fixes
+   * B6 (events on deleted branches) and B7 (cascade past one level).
    */
   const deleteNode = useCallback(
     (id: string) => {
-      setNodes(nodes.filter((n) => n.id !== id));
-      // Also delete all branches connected to this event
-      setEdges(edges.filter((e) => e.nodeId !== id));
+      const tree = buildTimelineTree(nodes, edges);
+      const collected = collectDescendantIds(tree, id);
+
+      if (!collected) {
+        // Event isn't in the tree (orphan with broken parentX, or
+        // already gone). Defensive single-id delete.
+        setNodes(nodes.filter((n) => n.id !== id));
+        setEdges(edges.filter((e) => e.nodeId !== id));
+      } else {
+        const { eventIds, edgeIds } = collected;
+        setNodes(nodes.filter((n) => !eventIds.has(n.id)));
+        setEdges(edges.filter((e) => !edgeIds.has(e.id)));
+      }
+
       onClearForm?.();
       onHistoryRecord?.();
     },

--- a/src/pages/timeline/hooks/useTimelineDragDrop.ts
+++ b/src/pages/timeline/hooks/useTimelineDragDrop.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from 'react';
 import { screenToWorld } from '../utils';
 import { LINE_X_POSITION } from '../constants';
+import { applyDragToTree, buildTimelineTree, flattenTree } from '../utils/timelineTree';
 import type { NodeT, EdgeT, Transform } from '../types';
 
 interface UseTimelineDragDropOptions {
@@ -14,8 +15,11 @@ interface UseTimelineDragDropOptions {
 }
 
 /**
- * Hook for managing drag & drop of timeline events
- * Includes recursive update logic for branches
+ * Hook for managing drag & drop of timeline events.
+ * Cascade logic walks the actual parent→child topology via
+ * applyDragToTree (see timelineTree.ts) so siblings on the same branch
+ * stay put when one of them moves, and grand-branches don't get a
+ * double shift.
  */
 export function useTimelineDragDrop({
   nodes,
@@ -29,64 +33,6 @@ export function useTimelineDragDrop({
   const [draggingNodeId, setDraggingNodeId] = useState<string | null>(null);
   const [dragStartX, setDragStartX] = useState<number>(0);
   const [dragStartNodeX, setDragStartNodeX] = useState<number>(LINE_X_POSITION);
-
-  /**
-   * Recursively update child nodes and edges when parent is moved
-   */
-  const updateRecursively = useCallback(
-    (
-      currentNodes: NodeT[],
-      currentEdges: EdgeT[],
-      fromX: number,
-      toX: number,
-      deltaX: number
-    ): { nodes: NodeT[]; edges: EdgeT[] } => {
-      let updatedNodes = [...currentNodes];
-      let updatedEdges = [...currentEdges];
-
-      // Find node IDs with parentX === fromX (before update)
-      const childNodeIds = updatedNodes.filter((n) => n.parentX === fromX).map((n) => n.id);
-
-      // Update parentX and x for these nodes
-      updatedNodes = updatedNodes.map((n) => {
-        if (n.parentX === fromX) {
-          // Determine current position of node
-          const currentX = n.x ?? LINE_X_POSITION;
-
-          // If node is on parent line (not offset), move to new line
-          // If node is offset, preserve the offset
-          const newX = currentX === fromX ? toX : currentX + deltaX;
-
-          return { ...n, x: newX, parentX: toX };
-        }
-        return n;
-      });
-
-      // For each child node, update its branches and recursively process
-      for (const childNodeId of childNodeIds) {
-        // Find branches from this node
-        const childEdges = updatedEdges.filter((e) => e.nodeId === childNodeId);
-
-        for (const childEdge of childEdges) {
-          const oldEdgeX = childEdge.x;
-          const newEdgeX = oldEdgeX + deltaX;
-
-          // Update x-coordinate of branch
-          updatedEdges = updatedEdges.map((e) =>
-            e.id === childEdge.id ? { ...e, x: newEdgeX } : e
-          );
-
-          // Recursively update descendants on this branch
-          const result = updateRecursively(updatedNodes, updatedEdges, oldEdgeX, newEdgeX, deltaX);
-          updatedNodes = result.nodes;
-          updatedEdges = result.edges;
-        }
-      }
-
-      return { nodes: updatedNodes, edges: updatedEdges };
-    },
-    []
-  );
 
   /**
    * Start dragging a node
@@ -118,24 +64,18 @@ export function useTimelineDragDrop({
       if (!node) return;
 
       const newX = worldPoint.x;
-      const oldX = node.x ?? LINE_X_POSITION; // Use CURRENT coordinate
+      const oldX = node.x ?? LINE_X_POSITION; // CURRENT coordinate
       const deltaX = newX - oldX;
+      if (deltaX === 0) return;
 
-      // Update x-coordinate of the dragged node
-      let updatedNodes = nodes.map((n) => (n.id === draggingNodeId ? { ...n, x: newX } : n));
-
-      // Update x-coordinate of all branches connected to dragged node
-      let updatedEdges = edges.map((edge) =>
-        edge.nodeId === draggingNodeId ? { ...edge, x: newX } : edge
-      );
-
-      // Recursively update all children
-      const result = updateRecursively(updatedNodes, updatedEdges, oldX, newX, deltaX);
+      const tree = buildTimelineTree(nodes, edges);
+      const nextTree = applyDragToTree(tree, draggingNodeId, newX, deltaX);
+      const result = flattenTree(nextTree);
 
       setNodes(result.nodes);
       setEdges(result.edges);
     },
-    [draggingNodeId, nodes, edges, svgRef, transform, setNodes, setEdges, updateRecursively]
+    [draggingNodeId, nodes, edges, svgRef, transform, setNodes, setEdges]
   );
 
   /**

--- a/src/pages/timeline/persistence.test.ts
+++ b/src/pages/timeline/persistence.test.ts
@@ -123,6 +123,28 @@ describe('normalizeImportedTimelineData (B5 healing)', () => {
     expect(onBranch.x).toBe(2100);
   });
 
+  it('CRITICAL: dedupes nodes/edges by id when loading a corrupted document', () => {
+    // A canvas damaged by the pre-fix exponential-drag bug can have
+    // the same node id present hundreds of times. normalize must collapse
+    // them to one occurrence on read so the canvas heals next save.
+    const normalized = normalizeImportedTimelineData({
+      currentAge: 30,
+      ageMax: 100,
+      nodes: [
+        { id: 'a', age: 10, label: 'A', isDecision: false, x: 2000 },
+        { id: 'a', age: 10, label: 'A', isDecision: false, x: 2000 },
+        { id: 'a', age: 10, label: 'A', isDecision: false, x: 2000 },
+        { id: 'b', age: 20, label: 'B', isDecision: false, x: 2000 },
+      ],
+      edges: [
+        { id: 'e1', x: 2100, startAge: 10, endAge: 30, color: '#000', nodeId: 'a' },
+        { id: 'e1', x: 2100, startAge: 10, endAge: 30, color: '#000', nodeId: 'a' },
+      ],
+    });
+    expect(normalized.nodes.map((n) => n.id).sort()).toEqual(['a', 'b']);
+    expect(normalized.edges.map((e) => e.id)).toEqual(['e1']);
+  });
+
   it('drops edges whose origin node is missing (existing behaviour)', () => {
     const normalized = normalizeImportedTimelineData({
       currentAge: 30,

--- a/src/pages/timeline/persistence.test.ts
+++ b/src/pages/timeline/persistence.test.ts
@@ -88,6 +88,55 @@ describe('timeline persistence', () => {
   });
 });
 
+describe('normalizeImportedTimelineData (B5 healing)', () => {
+  it('heals orphan nodes whose parentX points at no existing branch', () => {
+    const normalized = normalizeImportedTimelineData({
+      currentAge: 30,
+      ageMax: 100,
+      nodes: [
+        { id: 'a', age: 10, label: 'On main', isDecision: false, x: 2000 },
+        // parentX 9999 has no matching edge.x — orphaned
+        { id: 'b', age: 20, label: 'Orphan', isDecision: false, x: 9999, parentX: 9999 },
+      ],
+      edges: [],
+    });
+    const orphan = normalized.nodes.find((n) => n.id === 'b')!;
+    expect(orphan.parentX).toBeUndefined();
+    expect(orphan.x).toBeDefined();
+    expect(orphan.x).not.toBe(9999); // moved to main line
+  });
+
+  it('keeps nodes whose parentX matches an existing edge', () => {
+    const normalized = normalizeImportedTimelineData({
+      currentAge: 30,
+      ageMax: 100,
+      nodes: [
+        { id: 'origin', age: 10, label: 'Origin', isDecision: false, x: 2000 },
+        { id: 'on-branch', age: 20, label: 'On branch', isDecision: false, x: 2100, parentX: 2100 },
+      ],
+      edges: [
+        { id: 'e1', x: 2100, startAge: 10, endAge: 30, color: '#000', nodeId: 'origin' },
+      ],
+    });
+    const onBranch = normalized.nodes.find((n) => n.id === 'on-branch')!;
+    expect(onBranch.parentX).toBe(2100);
+    expect(onBranch.x).toBe(2100);
+  });
+
+  it('drops edges whose origin node is missing (existing behaviour)', () => {
+    const normalized = normalizeImportedTimelineData({
+      currentAge: 30,
+      ageMax: 100,
+      nodes: [{ id: 'a', age: 10, label: 'A', isDecision: false, x: 2000 }],
+      edges: [
+        { id: 'e1', x: 2100, startAge: 10, endAge: 30, color: '#000', nodeId: 'a' },
+        { id: 'broken', x: 2200, startAge: 10, endAge: 30, color: '#000', nodeId: 'missing' },
+      ],
+    });
+    expect(normalized.edges.map((x) => x.id)).toEqual(['e1']);
+  });
+});
+
 describe('hasTimelineContent', () => {
   it('treats post-clearAll state as empty so the biography-import CTA returns', () => {
     expect(

--- a/src/pages/timeline/persistence.ts
+++ b/src/pages/timeline/persistence.ts
@@ -68,13 +68,31 @@ export function normalizeImportedTimelineData(data: unknown): TimelineData {
   }
 
   const candidate = data as Partial<TimelineData>;
-  const rawNodes = Array.isArray(candidate.nodes) ? candidate.nodes.map(normalizeImportedNode).filter(Boolean) as NodeT[] : [];
+  // Dedupe by id at load — Firestore documents corrupted by the pre-fix
+  // duplication bug can have the same node id repeated thousands of
+  // times. First occurrence wins.
+  const dedupeById = <T extends { id: string }>(items: T[]): T[] => {
+    const seen = new Set<string>();
+    const out: T[] = [];
+    for (const item of items) {
+      if (seen.has(item.id)) continue;
+      seen.add(item.id);
+      out.push(item);
+    }
+    return out;
+  };
+
+  const rawNodesRaw = Array.isArray(candidate.nodes)
+    ? (candidate.nodes.map(normalizeImportedNode).filter(Boolean) as NodeT[])
+    : [];
+  const rawNodes = dedupeById(rawNodesRaw);
   const nodeIds = new Set(rawNodes.map((node) => node.id));
-  const edges = Array.isArray(candidate.edges)
+  const rawEdges = Array.isArray(candidate.edges)
     ? candidate.edges
         .map(normalizeImportedEdge)
         .filter((edge): edge is EdgeT => Boolean(edge) && nodeIds.has(edge.nodeId))
     : [];
+  const edges = dedupeById(rawEdges);
 
   // B5: heal orphan nodes whose parentX points at a now-missing branch.
   // After previous bugs (B6/B7) these accumulated in Firestore; on read

--- a/src/pages/timeline/persistence.ts
+++ b/src/pages/timeline/persistence.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_AGE_MAX, DEFAULT_CURRENT_AGE } from './constants';
+import { DEFAULT_AGE_MAX, DEFAULT_CURRENT_AGE, LINE_X_POSITION } from './constants';
 import type { EdgeT, NodeT, TimelineCanvas, TimelineData, TimelineDocument } from './types';
 
 export const DEFAULT_TIMELINE_NAME = 'Таймлайн 1';
@@ -68,13 +68,29 @@ export function normalizeImportedTimelineData(data: unknown): TimelineData {
   }
 
   const candidate = data as Partial<TimelineData>;
-  const nodes = Array.isArray(candidate.nodes) ? candidate.nodes.map(normalizeImportedNode).filter(Boolean) as NodeT[] : [];
-  const nodeIds = new Set(nodes.map((node) => node.id));
+  const rawNodes = Array.isArray(candidate.nodes) ? candidate.nodes.map(normalizeImportedNode).filter(Boolean) as NodeT[] : [];
+  const nodeIds = new Set(rawNodes.map((node) => node.id));
   const edges = Array.isArray(candidate.edges)
     ? candidate.edges
         .map(normalizeImportedEdge)
         .filter((edge): edge is EdgeT => Boolean(edge) && nodeIds.has(edge.nodeId))
     : [];
+
+  // B5: heal orphan nodes whose parentX points at a now-missing branch.
+  // After previous bugs (B6/B7) these accumulated in Firestore; on read
+  // we re-anchor them to the main line so the canvas doesn't render
+  // events floating on a non-existent branch.
+  const validEdgeXs = new Set(edges.map((e) => e.x));
+  const nodes = rawNodes.map((n) => {
+    if (
+      n.parentX !== undefined &&
+      n.parentX !== LINE_X_POSITION &&
+      !validEdgeXs.has(n.parentX)
+    ) {
+      return { ...n, x: LINE_X_POSITION, parentX: undefined };
+    }
+    return n;
+  });
   const computedMaxAge = Math.max(
     25,
     ...nodes.map((node) => node.age),

--- a/src/pages/timeline/utils/__tests__/timelineTree.test.ts
+++ b/src/pages/timeline/utils/__tests__/timelineTree.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   applyDragToTree,
   buildTimelineTree,
+  collectDescendantIds,
   findEventInTree,
   flattenTree,
   mapTree,
@@ -268,5 +269,54 @@ describe('applyDragToTree (B1 + B2 regression)', () => {
     const { tree } = setup();
     const next = applyDragToTree(tree, 'no-such-id', 9999, 100);
     expect(flattenTree(next)).toEqual(flattenTree(tree));
+  });
+});
+
+describe('collectDescendantIds (B6 + B7 regression)', () => {
+  // Same topology as applyDragToTree tests:
+  //   ROOT a → branch e1 → b, c → b's branch e2 → d
+  function setup() {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+      n('c', 25, { x: 2100, parentX: 2100 }),
+      n('d', 30, { x: 2200, parentX: 2200 }),
+    ];
+    const edges = [e('e1', 2100, 'a'), e('e2', 2200, 'b')];
+    return { tree: buildTimelineTree(nodes, edges) };
+  }
+
+  it('B6: deleting the root collects every descendant event AND edge', () => {
+    const { tree } = setup();
+    const collected = collectDescendantIds(tree, 'a');
+    expect(collected).not.toBeNull();
+    expect([...collected!.eventIds].sort()).toEqual(['a', 'b', 'c', 'd']);
+    expect([...collected!.edgeIds].sort()).toEqual(['e1', 'e2']);
+  });
+
+  it('B7: deleting an event on a branch cascades into its grand-branch', () => {
+    const { tree } = setup();
+    const collected = collectDescendantIds(tree, 'b');
+    expect([...collected!.eventIds].sort()).toEqual(['b', 'd']);
+    expect([...collected!.edgeIds]).toEqual(['e2']);
+  });
+
+  it('deleting a leaf event has no descendants beyond itself', () => {
+    const { tree } = setup();
+    const collected = collectDescendantIds(tree, 'd');
+    expect([...collected!.eventIds]).toEqual(['d']);
+    expect([...collected!.edgeIds]).toEqual([]);
+  });
+
+  it('deleting a sibling does NOT collect the other sibling', () => {
+    const { tree } = setup();
+    const collected = collectDescendantIds(tree, 'c');
+    expect([...collected!.eventIds]).toEqual(['c']); // no 'b'
+    expect([...collected!.edgeIds]).toEqual([]);
+  });
+
+  it('returns null when the event is not in the tree', () => {
+    const { tree } = setup();
+    expect(collectDescendantIds(tree, 'no-such-id')).toBeNull();
   });
 });

--- a/src/pages/timeline/utils/__tests__/timelineTree.test.ts
+++ b/src/pages/timeline/utils/__tests__/timelineTree.test.ts
@@ -102,6 +102,38 @@ describe('buildTimelineTree', () => {
     expect(out.map((x) => x.id)).toEqual(['e1']);
   });
 
+  it('CRITICAL: a node only enters the tree once, even when two branches share x', () => {
+    // Real production regression — two edges with the same x both
+    // pulled the same nodesByParentX[x] list, so events on the branch
+    // got duplicated. Drag → flatten → setNodes then doubled the
+    // state on every mousemove, blowing up to tens of thousands.
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('on-shared', 20, { x: 2100, parentX: 2100 }),
+    ];
+    const edges = [
+      e('e1', 2100, 'a'),
+      e('e2', 2100, 'a'), // legacy: same x as e1
+    ];
+    const flat = flattenTree(buildTimelineTree(nodes, edges));
+    expect(flat.nodes.filter((x) => x.id === 'on-shared')).toHaveLength(1);
+  });
+
+  it('CRITICAL: drag flatten/build is idempotent (no state explosion)', () => {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('on-shared', 20, { x: 2100, parentX: 2100 }),
+    ];
+    const edges = [e('e1', 2100, 'a'), e('e2', 2100, 'a')];
+
+    let state = { nodes, edges };
+    for (let i = 0; i < 20; i++) {
+      state = flattenTree(buildTimelineTree(state.nodes, state.edges));
+    }
+    // Without dedup this would be ~2^20. With dedup it stays at 2.
+    expect(state.nodes).toHaveLength(2);
+  });
+
   it('rescues orphan nodes (parentX with no matching edge) as roots', () => {
     const nodes = [
       n('a', 10, { x: LINE_X_POSITION }),

--- a/src/pages/timeline/utils/__tests__/timelineTree.test.ts
+++ b/src/pages/timeline/utils/__tests__/timelineTree.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyBranchDeletionToFlat,
   applyDragToTree,
   buildTimelineTree,
   collectDescendantIds,
@@ -318,5 +319,83 @@ describe('collectDescendantIds (B6 + B7 regression)', () => {
   it('returns null when the event is not in the tree', () => {
     const { tree } = setup();
     expect(collectDescendantIds(tree, 'no-such-id')).toBeNull();
+  });
+});
+
+describe('applyBranchDeletionToFlat (B8 regression)', () => {
+  // Topology:
+  //   ROOT a (x=2000) on main line
+  //     └─ branch e1 (x=2100)
+  //         └─ b (x=2100, parentX=2100)
+  //             └─ branch e2 (x=2200)
+  //                 └─ c (x=2230, parentX=2200, +30 offset)
+  // Deleting e1 should:
+  //  - move b to the main line (x=2000), parentX=undefined (since a is root)
+  //  - shift e2 to x=2100 (delta = -100), c follows to x=2130 (offset preserved)
+  function setup() {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+      n('c', 30, { x: 2230, parentX: 2200 }),
+    ];
+    const edges = [e('e1', 2100, 'a'), e('e2', 2200, 'b')];
+    return { nodes, edges };
+  }
+
+  it('B8: migrates events to the parent line (node.x updated, not just parentX)', () => {
+    const { nodes, edges } = setup();
+    const out = applyBranchDeletionToFlat(nodes, edges, 'e1');
+    const b = out.nodes.find((x) => x.id === 'b')!;
+    expect(b.x).toBe(LINE_X_POSITION); // collapsed onto main line
+    expect(b.parentX).toBeUndefined(); // origin a is root → migrant becomes root
+  });
+
+  it('drops the deleted branch from edges', () => {
+    const { nodes, edges } = setup();
+    const out = applyBranchDeletionToFlat(nodes, edges, 'e1');
+    expect(out.edges.find((x) => x.id === 'e1')).toBeUndefined();
+  });
+
+  it('drags grand-branch e2 with the migrated event b', () => {
+    const { nodes, edges } = setup();
+    const out = applyBranchDeletionToFlat(nodes, edges, 'e1');
+    const e2 = out.edges.find((x) => x.id === 'e2')!;
+    expect(e2.x).toBe(2100); // 2200 + (2000 - 2100)
+  });
+
+  it('preserves per-event offset on grand-branch descendants', () => {
+    const { nodes, edges } = setup();
+    const out = applyBranchDeletionToFlat(nodes, edges, 'e1');
+    const c = out.nodes.find((x) => x.id === 'c')!;
+    expect(c.x).toBe(2130); // 2230 + delta(-100), offset of +30 preserved
+    expect(c.parentX).toBe(2100); // re-anchored to the moved e2
+  });
+
+  it('migrates onto a non-root line when origin event lives on another branch', () => {
+    // a (root) → branch e1 → b on e1 → branch e2 → c on e2 → branch e3 → d on e3
+    // delete e3 → d should move to b's line (x=2100, parentX=undefined? no — parent of d is c, which lives on e2)
+    // After deletion, d should sit at c.x with parentX=e2.x.
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+      n('c', 30, { x: 2200, parentX: 2200 }),
+      n('d', 40, { x: 2300, parentX: 2300 }),
+    ];
+    const edges = [
+      e('e1', 2100, 'a'),
+      e('e2', 2200, 'b'),
+      e('e3', 2300, 'c'),
+    ];
+    const out = applyBranchDeletionToFlat(nodes, edges, 'e3');
+    const d = out.nodes.find((x) => x.id === 'd')!;
+    expect(d.x).toBe(2200); // c's x
+    expect(d.parentX).toBe(2200); // c lives on e2 (x=2200)
+  });
+
+  it('returns input unchanged when edge id is unknown', () => {
+    const { nodes, edges } = setup();
+    const out = applyBranchDeletionToFlat(nodes, edges, 'no-such-edge');
+    expect(out.nodes).toEqual(nodes);
+    expect(out.edges).toEqual(edges);
   });
 });

--- a/src/pages/timeline/utils/__tests__/timelineTree.test.ts
+++ b/src/pages/timeline/utils/__tests__/timelineTree.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildTimelineTree,
+  findEventInTree,
+  flattenTree,
+  mapTree,
+  type TimelineTreeNode,
+} from '../timelineTree';
+import { LINE_X_POSITION } from '../../constants';
+import type { EdgeT, NodeT } from '../../types';
+
+function n(
+  id: string,
+  age: number,
+  overrides: Partial<NodeT> = {}
+): NodeT {
+  return {
+    id,
+    age,
+    label: id,
+    isDecision: false,
+    x: LINE_X_POSITION,
+    ...overrides,
+  };
+}
+
+function e(id: string, x: number, nodeId: string, overrides: Partial<EdgeT> = {}): EdgeT {
+  return {
+    id,
+    x,
+    nodeId,
+    startAge: 18,
+    endAge: 30,
+    color: '#000',
+    ...overrides,
+  };
+}
+
+describe('buildTimelineTree', () => {
+  it('places main-line events as roots', () => {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: LINE_X_POSITION }),
+    ];
+    const tree = buildTimelineTree(nodes, []);
+    expect(tree).toHaveLength(2);
+    expect(tree.map((t) => t.data.id)).toEqual(['a', 'b']);
+    expect(tree[0].branches).toEqual([]);
+  });
+
+  it('treats parentX === undefined as a root', () => {
+    const nodes = [n('a', 5, { x: LINE_X_POSITION, parentX: undefined })];
+    expect(buildTimelineTree(nodes, [])[0].data.id).toBe('a');
+  });
+
+  it('attaches a branch to its origin event', () => {
+    const nodes = [n('a', 10, { x: LINE_X_POSITION })];
+    const edges = [e('e1', 2100, 'a')];
+    const tree = buildTimelineTree(nodes, edges);
+    expect(tree[0].branches).toHaveLength(1);
+    expect(tree[0].branches[0].data.id).toBe('e1');
+    expect(tree[0].branches[0].events).toEqual([]);
+  });
+
+  it('places branch events under the right branch', () => {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+      n('c', 25, { x: 2100, parentX: 2100 }),
+    ];
+    const edges = [e('e1', 2100, 'a')];
+    const tree = buildTimelineTree(nodes, edges);
+    const branch = tree[0].branches[0];
+    expect(branch.events.map((ev) => ev.data.id)).toEqual(['b', 'c']);
+  });
+
+  it('handles a deep branch (root → branch → event → branch → event)', () => {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+      n('c', 30, { x: 2200, parentX: 2200 }),
+    ];
+    const edges = [e('e1', 2100, 'a'), e('e2', 2200, 'b')];
+    const tree = buildTimelineTree(nodes, edges);
+    expect(tree[0].branches[0].events[0].branches[0].events[0].data.id).toBe('c');
+  });
+
+  it('keeps multiple branches from one event', () => {
+    const nodes = [n('a', 10, { x: LINE_X_POSITION })];
+    const edges = [e('e1', 2100, 'a'), e('e2', 2200, 'a')];
+    const tree = buildTimelineTree(nodes, edges);
+    expect(tree[0].branches.map((b) => b.data.id)).toEqual(['e1', 'e2']);
+  });
+
+  it('drops edges whose origin node is missing', () => {
+    const nodes = [n('a', 10, { x: LINE_X_POSITION })];
+    const edges = [e('e1', 2100, 'a'), e('orphan', 2300, 'missing')];
+    const { edges: out } = flattenTree(buildTimelineTree(nodes, edges));
+    expect(out.map((x) => x.id)).toEqual(['e1']);
+  });
+
+  it('rescues orphan nodes (parentX with no matching edge) as roots', () => {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('orphan', 20, { x: 9999, parentX: 9999 }),
+    ];
+    const tree = buildTimelineTree(nodes, []);
+    expect(tree.map((t) => t.data.id)).toContain('orphan');
+  });
+});
+
+describe('flattenTree', () => {
+  it('round-trips through buildTimelineTree → flattenTree', () => {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+      n('c', 25, { x: 2100, parentX: 2100 }),
+      n('d', 30, { x: 2200, parentX: 2200 }),
+    ];
+    const edges = [e('e1', 2100, 'a'), e('e2', 2200, 'b')];
+    const out = flattenTree(buildTimelineTree(nodes, edges));
+    expect(new Set(out.nodes.map((x) => x.id))).toEqual(new Set(['a', 'b', 'c', 'd']));
+    expect(new Set(out.edges.map((x) => x.id))).toEqual(new Set(['e1', 'e2']));
+  });
+
+  it('preserves node fields (label, age, sphere, x, parentX)', () => {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION, sphere: 'education', label: 'Школа' }),
+    ];
+    const out = flattenTree(buildTimelineTree(nodes, []));
+    expect(out.nodes[0]).toMatchObject({
+      id: 'a',
+      age: 10,
+      sphere: 'education',
+      label: 'Школа',
+    });
+  });
+});
+
+describe('findEventInTree', () => {
+  it('finds a deeply nested event', () => {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+      n('c', 30, { x: 2200, parentX: 2200 }),
+    ];
+    const edges = [e('e1', 2100, 'a'), e('e2', 2200, 'b')];
+    const tree = buildTimelineTree(nodes, edges);
+    expect(findEventInTree(tree, 'c')?.data.age).toBe(30);
+  });
+
+  it('returns null for unknown id', () => {
+    const tree = buildTimelineTree([n('a', 10, { x: LINE_X_POSITION })], []);
+    expect(findEventInTree(tree, 'missing')).toBeNull();
+  });
+});
+
+describe('mapTree', () => {
+  it('lets you transform every event without mutating original', () => {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+    ];
+    const edges = [e('e1', 2100, 'a')];
+    const tree = buildTimelineTree(nodes, edges);
+    const bumped = mapTree(tree, {
+      event: (ev: TimelineTreeNode) => ({
+        ...ev,
+        data: { ...ev.data, age: ev.data.age + 100 },
+      }),
+    });
+    const flat = flattenTree(bumped);
+    expect(flat.nodes.map((x) => x.age).sort()).toEqual([110, 120]);
+    // Original tree untouched
+    expect(tree[0].data.age).toBe(10);
+  });
+
+  it('lets you transform branches (e.g. shift edge.x)', () => {
+    const nodes = [n('a', 10, { x: LINE_X_POSITION })];
+    const edges = [e('e1', 2100, 'a')];
+    const tree = buildTimelineTree(nodes, edges);
+    const shifted = mapTree(tree, {
+      branch: (b) => ({ ...b, data: { ...b.data, x: b.data.x + 50 } }),
+    });
+    expect(flattenTree(shifted).edges[0].x).toBe(2150);
+  });
+});

--- a/src/pages/timeline/utils/__tests__/timelineTree.test.ts
+++ b/src/pages/timeline/utils/__tests__/timelineTree.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  applyDragToTree,
   buildTimelineTree,
   findEventInTree,
   flattenTree,
@@ -183,5 +184,89 @@ describe('mapTree', () => {
       branch: (b) => ({ ...b, data: { ...b.data, x: b.data.x + 50 } }),
     });
     expect(flattenTree(shifted).edges[0].x).toBe(2150);
+  });
+});
+
+describe('applyDragToTree (B1 + B2 regression)', () => {
+  // Topology used across these tests:
+  //   ROOT (a, x=2000)
+  //     └─ branch e1 (x=2100)
+  //         ├─ b (x=2100, parentX=2100)   ← sibling on the branch
+  //         ├─ c (x=2100, parentX=2100)   ← sibling on the branch
+  //         └─ b: branch e2 (x=2200)      ← grand-branch from b
+  //             └─ d (x=2200, parentX=2200)
+  function setup() {
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+      n('c', 25, { x: 2100, parentX: 2100 }),
+      n('d', 30, { x: 2200, parentX: 2200 }),
+    ];
+    const edges = [e('e1', 2100, 'a'), e('e2', 2200, 'b')];
+    return { tree: buildTimelineTree(nodes, edges), nodes, edges };
+  }
+
+  it('B1: dragging a sibling event (b) does NOT move other siblings (c)', () => {
+    const { tree } = setup();
+    const next = applyDragToTree(tree, 'b', 2050, -50); // b moves left by 50
+    const flat = flattenTree(next);
+    const c = flat.nodes.find((x) => x.id === 'c')!;
+    expect(c.x).toBe(2100); // unchanged
+    expect(c.parentX).toBe(2100); // still on the same branch e1
+  });
+
+  it('B1: parent branch e1 stays put when one of its events moves', () => {
+    const { tree } = setup();
+    const next = applyDragToTree(tree, 'b', 2050, -50);
+    const flat = flattenTree(next);
+    expect(flat.edges.find((x) => x.id === 'e1')!.x).toBe(2100); // unchanged
+  });
+
+  it("B2: child branch e2 from b shifts by exactly deltaX (not 2×deltaX)", () => {
+    const { tree } = setup();
+    const next = applyDragToTree(tree, 'b', 2050, -50);
+    const flat = flattenTree(next);
+    expect(flat.edges.find((x) => x.id === 'e2')!.x).toBe(2150); // 2200 + (-50)
+  });
+
+  it('B2: event on grand-branch (d) shifts by exactly deltaX, parentX rebound', () => {
+    const { tree } = setup();
+    const next = applyDragToTree(tree, 'b', 2050, -50);
+    const flat = flattenTree(next);
+    const d = flat.nodes.find((x) => x.id === 'd')!;
+    expect(d.x).toBe(2150); // 2200 - 50
+    expect(d.parentX).toBe(2150); // re-anchored to the moved e2
+  });
+
+  it('preserves per-node offset on shifted descendants', () => {
+    // Like setup() but d sits 30px to the right of its branch e2
+    const nodes = [
+      n('a', 10, { x: LINE_X_POSITION }),
+      n('b', 20, { x: 2100, parentX: 2100 }),
+      n('d', 30, { x: 2230, parentX: 2200 }), // +30 offset
+    ];
+    const edges = [e('e1', 2100, 'a'), e('e2', 2200, 'b')];
+    const next = applyDragToTree(buildTimelineTree(nodes, edges), 'b', 2050, -50);
+    const d = flattenTree(next).nodes.find((x) => x.id === 'd')!;
+    expect(d.x).toBe(2180); // 2230 - 50, offset preserved
+    expect(d.parentX).toBe(2150); // re-anchored to the new branch x
+  });
+
+  it('dragging the root event moves its branches AND their events together', () => {
+    const { tree } = setup();
+    const next = applyDragToTree(tree, 'a', 2030, 30); // root moves right by 30
+    const flat = flattenTree(next);
+    expect(flat.nodes.find((x) => x.id === 'a')!.x).toBe(2030);
+    expect(flat.edges.find((x) => x.id === 'e1')!.x).toBe(2130); // 2100 + 30
+    expect(flat.nodes.find((x) => x.id === 'b')!.x).toBe(2130); // followed e1
+    expect(flat.nodes.find((x) => x.id === 'b')!.parentX).toBe(2130);
+    expect(flat.edges.find((x) => x.id === 'e2')!.x).toBe(2230); // grand-branch
+    expect(flat.nodes.find((x) => x.id === 'd')!.x).toBe(2230);
+  });
+
+  it('returns tree unchanged when dragged id is not found', () => {
+    const { tree } = setup();
+    const next = applyDragToTree(tree, 'no-such-id', 9999, 100);
+    expect(flattenTree(next)).toEqual(flattenTree(tree));
   });
 });

--- a/src/pages/timeline/utils/timelineTree.ts
+++ b/src/pages/timeline/utils/timelineTree.ts
@@ -65,28 +65,43 @@ export function buildTimelineTree(nodes: NodeT[], edges: EdgeT[]): TimelineTree 
     }
   }
 
-  // Track which edge.x have been claimed by a parent so that orphan
-  // detection knows what's reachable. Multiple edges can share the same
-  // x (legacy bug B12): the tree picks the first one and treats the rest
-  // as siblings under the same node — flattenTree preserves them.
+  // CRITICAL: every event must enter the tree exactly once. If two
+  // legacy branches share the same edge.x, both nodesByParentX[edge.x]
+  // lookups return the same array — without this dedup, flattenTree
+  // would output the events twice, drag → flatten → setNodes
+  // re-feeds the doubled state on the next move, and node count
+  // explodes 2× per mousemove (real production incident:
+  // ~60k events after a few seconds of dragging).
+  const claimedNodeIds = new Set<string>();
   const claimedEdgeXs = new Set<number>();
 
   function buildEvent(node: NodeT): TimelineTreeNode {
+    claimedNodeIds.add(node.id);
     const branches = (edgesByOrigin.get(node.id) ?? []).map((edge): TimelineTreeBranch => {
       claimedEdgeXs.add(edge.x);
-      const eventsOnBranch = (nodesByParentX.get(edge.x) ?? []).map(buildEvent);
+      const candidates = nodesByParentX.get(edge.x) ?? [];
+      const eventsOnBranch: TimelineTreeNode[] = [];
+      for (const candidate of candidates) {
+        if (claimedNodeIds.has(candidate.id)) continue;
+        eventsOnBranch.push(buildEvent(candidate));
+      }
       return { data: edge, events: eventsOnBranch };
     });
     return { data: node, branches };
   }
 
-  const tree: TimelineTree = rootNodes.map(buildEvent);
+  const tree: TimelineTree = [];
+  for (const root of rootNodes) {
+    if (claimedNodeIds.has(root.id)) continue;
+    tree.push(buildEvent(root));
+  }
 
   // Orphan nodes whose parentX points at no existing edge — surface them
   // as extra roots so they don't silently disappear.
   for (const [parentX, orphans] of nodesByParentX) {
     if (claimedEdgeXs.has(parentX)) continue;
     for (const orphan of orphans) {
+      if (claimedNodeIds.has(orphan.id)) continue;
       tree.push(buildEvent(orphan));
     }
   }

--- a/src/pages/timeline/utils/timelineTree.ts
+++ b/src/pages/timeline/utils/timelineTree.ts
@@ -195,6 +195,89 @@ function shiftEventOnShiftedBranch(
 }
 
 /**
+ * Delete a branch and migrate every event living on it to the parent
+ * line (the line where the branch's origin event sits). Each migrated
+ * event also brings its own grand-branches and their events along —
+ * those keep their per-event offsets relative to their own branch.
+ *
+ * Fixes B8 — the previous implementation only rewrote `parentX` and
+ * left `node.x` on the deleted branch's coordinate, so events visually
+ * "hung in the air" instead of joining the parent line.
+ *
+ * Returns the original arrays unchanged if the edge isn't found.
+ */
+export function applyBranchDeletionToFlat(
+  nodes: NodeT[],
+  edges: EdgeT[],
+  edgeId: string
+): { nodes: NodeT[]; edges: EdgeT[] } {
+  const tree = buildTimelineTree(nodes, edges);
+
+  const branchEdge = edges.find((e) => e.id === edgeId);
+  if (!branchEdge) return { nodes, edges };
+
+  const originInTree = findEventInTree(tree, branchEdge.nodeId);
+  if (!originInTree) {
+    // Origin event missing — drop the edge, leave events that pointed
+    // at it as orphans recoverable by the next operation. Defensive.
+    return { nodes, edges: edges.filter((e) => e.id !== edgeId) };
+  }
+  const branchInTree = originInTree.branches.find((b) => b.data.id === edgeId);
+  if (!branchInTree) return { nodes, edges };
+
+  const newParentLineX = originInTree.data.x ?? LINE_X_POSITION;
+  const newAnchorParentX = originInTree.data.parentX; // where origin lives
+
+  const updatedNodes = new Map<string, NodeT>();
+  const updatedEdges = new Map<string, EdgeT>();
+
+  // Top-level migrant: collapses to the new parent line (no offset).
+  function migrateTopLevel(event: TimelineTreeNode) {
+    const oldX = event.data.x ?? LINE_X_POSITION;
+    const deltaX = newParentLineX - oldX;
+    updatedNodes.set(event.data.id, {
+      ...event.data,
+      x: newParentLineX,
+      parentX: newAnchorParentX,
+    });
+    for (const branch of event.branches) {
+      shiftBranch(branch, deltaX);
+    }
+  }
+
+  // Descendant migrant: preserves its per-event offset relative to its
+  // own branch — only the absolute coordinates slide by deltaX.
+  function migrateDescendant(event: TimelineTreeNode, deltaX: number, newOwnParentX: number) {
+    const oldX = event.data.x ?? LINE_X_POSITION;
+    updatedNodes.set(event.data.id, {
+      ...event.data,
+      x: oldX + deltaX,
+      parentX: newOwnParentX,
+    });
+    for (const branch of event.branches) {
+      shiftBranch(branch, deltaX);
+    }
+  }
+
+  function shiftBranch(branch: TimelineTreeBranch, deltaX: number) {
+    const newBranchX = branch.data.x + deltaX;
+    updatedEdges.set(branch.data.id, { ...branch.data, x: newBranchX });
+    for (const child of branch.events) {
+      migrateDescendant(child, deltaX, newBranchX);
+    }
+  }
+
+  for (const child of branchInTree.events) migrateTopLevel(child);
+
+  return {
+    nodes: nodes.map((n) => updatedNodes.get(n.id) ?? n),
+    edges: edges
+      .filter((e) => e.id !== edgeId)
+      .map((e) => updatedEdges.get(e.id) ?? e),
+  };
+}
+
+/**
  * Collect every event id and every edge id reachable from `eventId` in
  * the tree, including `eventId` itself. Returns null if `eventId` is
  * not in the tree (caller should fall back to id-only delete).

--- a/src/pages/timeline/utils/timelineTree.ts
+++ b/src/pages/timeline/utils/timelineTree.ts
@@ -1,0 +1,160 @@
+/**
+ * Tree representation of a timeline (events + branches).
+ *
+ * The Firestore wire-format keeps `nodes[]` and `edges[]` as flat arrays,
+ * which makes cascade operations (drag, delete, age-edit) error-prone:
+ * relationships are encoded across two fields (`node.parentX` and
+ * `edge.nodeId`) and can drift out of sync. This module rebuilds the
+ * intended parent → child topology in memory so operations can walk the
+ * actual tree, then serialises it back to flat arrays.
+ *
+ * Topology:
+ *   main line (LINE_X_POSITION) holds root events.
+ *   every event can spawn multiple child branches (edges where
+ *     edge.nodeId === event.id).
+ *   every branch holds its own events (nodes where node.parentX
+ *     equals branch.x), and those events can spawn deeper branches.
+ *
+ * Convention:
+ *   - `node.parentX === LINE_X_POSITION` (or `undefined`) = root.
+ *   - `node.parentX === edge.x` = node lives on `edge`.
+ *   - `edge.nodeId === event.id` = branch originates from `event`.
+ *
+ * Orphan tolerance: a node whose `parentX` matches no existing edge is
+ * treated as a root (we don't drop user data). An edge whose `nodeId`
+ * matches no event is dropped — there's nothing to anchor it to.
+ */
+import { LINE_X_POSITION } from '../constants';
+import type { EdgeT, NodeT } from '../types';
+
+export interface TimelineTreeNode {
+  data: NodeT;
+  branches: TimelineTreeBranch[];
+}
+
+export interface TimelineTreeBranch {
+  data: EdgeT;
+  events: TimelineTreeNode[];
+}
+
+export type TimelineTree = TimelineTreeNode[];
+
+function isRootNode(node: NodeT): boolean {
+  const px = node.parentX;
+  return px === undefined || px === LINE_X_POSITION;
+}
+
+export function buildTimelineTree(nodes: NodeT[], edges: EdgeT[]): TimelineTree {
+  const edgesByOrigin = new Map<string, EdgeT[]>();
+  for (const edge of edges) {
+    const list = edgesByOrigin.get(edge.nodeId) ?? [];
+    list.push(edge);
+    edgesByOrigin.set(edge.nodeId, list);
+  }
+
+  const nodesByParentX = new Map<number, NodeT[]>();
+  const rootNodes: NodeT[] = [];
+  for (const node of nodes) {
+    if (isRootNode(node)) {
+      rootNodes.push(node);
+    } else {
+      const px = node.parentX as number;
+      const list = nodesByParentX.get(px) ?? [];
+      list.push(node);
+      nodesByParentX.set(px, list);
+    }
+  }
+
+  // Track which edge.x have been claimed by a parent so that orphan
+  // detection knows what's reachable. Multiple edges can share the same
+  // x (legacy bug B12): the tree picks the first one and treats the rest
+  // as siblings under the same node — flattenTree preserves them.
+  const claimedEdgeXs = new Set<number>();
+
+  function buildEvent(node: NodeT): TimelineTreeNode {
+    const branches = (edgesByOrigin.get(node.id) ?? []).map((edge): TimelineTreeBranch => {
+      claimedEdgeXs.add(edge.x);
+      const eventsOnBranch = (nodesByParentX.get(edge.x) ?? []).map(buildEvent);
+      return { data: edge, events: eventsOnBranch };
+    });
+    return { data: node, branches };
+  }
+
+  const tree: TimelineTree = rootNodes.map(buildEvent);
+
+  // Orphan nodes whose parentX points at no existing edge — surface them
+  // as extra roots so they don't silently disappear.
+  for (const [parentX, orphans] of nodesByParentX) {
+    if (claimedEdgeXs.has(parentX)) continue;
+    for (const orphan of orphans) {
+      tree.push(buildEvent(orphan));
+    }
+  }
+
+  return tree;
+}
+
+export function flattenTree(tree: TimelineTree): { nodes: NodeT[]; edges: EdgeT[] } {
+  const nodes: NodeT[] = [];
+  const edges: EdgeT[] = [];
+
+  function walkEvent(event: TimelineTreeNode) {
+    nodes.push(event.data);
+    for (const branch of event.branches) {
+      edges.push(branch.data);
+      for (const child of branch.events) walkEvent(child);
+    }
+  }
+
+  for (const root of tree) walkEvent(root);
+  return { nodes, edges };
+}
+
+/**
+ * Find the event with the given id anywhere in the tree, returning the
+ * subtree rooted at that event. Returns null if not found.
+ */
+export function findEventInTree(tree: TimelineTree, eventId: string): TimelineTreeNode | null {
+  for (const root of tree) {
+    const hit = findInSubtree(root, eventId);
+    if (hit) return hit;
+  }
+  return null;
+}
+
+function findInSubtree(event: TimelineTreeNode, eventId: string): TimelineTreeNode | null {
+  if (event.data.id === eventId) return event;
+  for (const branch of event.branches) {
+    for (const child of branch.events) {
+      const hit = findInSubtree(child, eventId);
+      if (hit) return hit;
+    }
+  }
+  return null;
+}
+
+/**
+ * Map every event in the tree, optionally also transforming branches.
+ * Used by drag/edit operations to produce a new tree without mutating.
+ */
+export function mapTree(
+  tree: TimelineTree,
+  mappers: {
+    event?: (event: TimelineTreeNode, parentBranch: TimelineTreeBranch | null) => TimelineTreeNode;
+    branch?: (branch: TimelineTreeBranch, parentEvent: TimelineTreeNode) => TimelineTreeBranch;
+  }
+): TimelineTree {
+  const mapEvent = (event: TimelineTreeNode, parentBranch: TimelineTreeBranch | null): TimelineTreeNode => {
+    const mapped = mappers.event ? mappers.event(event, parentBranch) : event;
+    const mappedBranches = mapped.branches.map((branch) => {
+      const branchMapped = mappers.branch ? mappers.branch(branch, mapped) : branch;
+      return {
+        ...branchMapped,
+        events: branchMapped.events.map((child) => mapEvent(child, branchMapped)),
+      };
+    });
+    return { ...mapped, branches: mappedBranches };
+  };
+
+  return tree.map((root) => mapEvent(root, null));
+}

--- a/src/pages/timeline/utils/timelineTree.ts
+++ b/src/pages/timeline/utils/timelineTree.ts
@@ -195,6 +195,39 @@ function shiftEventOnShiftedBranch(
 }
 
 /**
+ * Collect every event id and every edge id reachable from `eventId` in
+ * the tree, including `eventId` itself. Returns null if `eventId` is
+ * not in the tree (caller should fall back to id-only delete).
+ *
+ * Used by deleteNode to drop the entire subtree of an event in one
+ * pass — fixes B6 (orphan branch events left behind) and B7 (cascade
+ * not going past one level).
+ */
+export function collectDescendantIds(
+  tree: TimelineTree,
+  eventId: string
+): { eventIds: Set<string>; edgeIds: Set<string> } | null {
+  const subtree = findEventInTree(tree, eventId);
+  if (!subtree) return null;
+  const eventIds = new Set<string>();
+  const edgeIds = new Set<string>();
+  collectSubtreeIds(subtree, eventIds, edgeIds);
+  return { eventIds, edgeIds };
+}
+
+function collectSubtreeIds(
+  event: TimelineTreeNode,
+  eventIds: Set<string>,
+  edgeIds: Set<string>
+): void {
+  eventIds.add(event.data.id);
+  for (const branch of event.branches) {
+    edgeIds.add(branch.data.id);
+    for (const child of branch.events) collectSubtreeIds(child, eventIds, edgeIds);
+  }
+}
+
+/**
  * Map every event in the tree, optionally also transforming branches.
  * Used by drag/edit operations to produce a new tree without mutating.
  */

--- a/src/pages/timeline/utils/timelineTree.ts
+++ b/src/pages/timeline/utils/timelineTree.ts
@@ -134,6 +134,67 @@ function findInSubtree(event: TimelineTreeNode, eventId: string): TimelineTreeNo
 }
 
 /**
+ * Apply a drag to the tree: change the dragged event's x to newSelfX,
+ * and shift all of its descendants (branches + their events) by deltaX.
+ *
+ * Sibling events on the dragged event's parent branch DO NOT move —
+ * the drag is purely a subtree operation. This is the structural
+ * answer to B1 (siblings followed) and B2 (double-shift on grand-
+ * branches), both of which only existed because the old implementation
+ * walked the flat arrays via `parentX === fromX` matching.
+ */
+export function applyDragToTree(
+  tree: TimelineTree,
+  draggedId: string,
+  newSelfX: number,
+  deltaX: number
+): TimelineTree {
+  const transformEvent = (event: TimelineTreeNode): TimelineTreeNode => {
+    if (event.data.id === draggedId) {
+      return {
+        ...event,
+        data: { ...event.data, x: newSelfX },
+        branches: event.branches.map((b) => shiftBranchSubtree(b, deltaX)),
+      };
+    }
+    return {
+      ...event,
+      branches: event.branches.map((b) => ({
+        ...b,
+        events: b.events.map(transformEvent),
+      })),
+    };
+  };
+  return tree.map(transformEvent);
+}
+
+function shiftBranchSubtree(branch: TimelineTreeBranch, deltaX: number): TimelineTreeBranch {
+  const newBranchX = branch.data.x + deltaX;
+  return {
+    ...branch,
+    data: { ...branch.data, x: newBranchX },
+    events: branch.events.map((child) => shiftEventOnShiftedBranch(child, newBranchX, deltaX)),
+  };
+}
+
+function shiftEventOnShiftedBranch(
+  event: TimelineTreeNode,
+  newParentX: number,
+  deltaX: number
+): TimelineTreeNode {
+  const currentX = event.data.x ?? LINE_X_POSITION;
+  return {
+    ...event,
+    data: {
+      ...event.data,
+      x: currentX + deltaX, // preserve any per-node offset
+      parentX: newParentX,
+    },
+    branches: event.branches.map((b) => shiftBranchSubtree(b, deltaX)),
+  };
+}
+
+/**
  * Map every event in the tree, optionally also transforming branches.
  * Used by drag/edit operations to produce a new tree without mutating.
  */


### PR DESCRIPTION
## Summary

Replaces flat-array \`parentX === fromX\` matching in timeline cascade ops with a proper parent→child tree representation, fixing 12 audit-backlog bugs and one production-grade exponential-state-blow-up.

## What's in here

**New plumbing**
- \`src/pages/timeline/utils/timelineTree.ts\` — \`buildTimelineTree\` / \`flattenTree\` / \`findEventInTree\` / \`mapTree\` / \`applyDragToTree\` / \`collectDescendantIds\` / \`applyBranchDeletionToFlat\`. Tree is rebuilt in memory from flat \`nodes[]\`/\`edges[]\` (Firestore wire format unchanged) and serialised back after every operation.

**Cascade fixes via the tree**
- B1+B2: drag respects branch topology — siblings on the parent branch stop following the dragged event, grand-branches no longer get a 2×deltaX double shift.
- B6+B7: deleting an event removes its full subtree (events on its branches, their grand-branches, recursively) instead of leaving orphans.
- B8: deleting a branch migrates its events onto the parent line (collapsing per-event offsets), grand-branches and great-grand events follow with deltaX, per-event offsets preserved.
- B10: editing the age of a branch origin slides \`edge.startAge\`/\`endAge\` by the same delta (length preserved), \`endAge\` clamped at \`ageMax\`.

**Range validators**
- B11: editing a branch event's age past its branch range refuses with an actionable message.
- B13: \`extendBranch\` refuses to create a branch reaching past \`ageMax\`.
- B14: \`updateBranchLength\` refuses to shorten the branch past existing events on it (lists offenders).
- B12: \`extendBranch\` walks +100px until it finds a free \`x\` so a sub-branch doesn't visually overlap its parent.

**Identity & healing**
- B15: \`selectedBranchX\` (number, ambiguous on shared x) → \`selectedBranchId\` (string, primary key). All call sites updated.
- B5: \`normalizeImportedTimelineData\` heals orphan nodes whose \`parentX\` points at a missing branch — moves them to the main line on load.

**B3, B4 — closed as not real bugs**: drag is X-only (Y/age unchanged so \`ageMax\` is irrelevant), and \`worldWidth\` auto-grows from \`useMemo\` over node/edge x-coords, so dragging "off canvas" doesn't lose data.

**CRITICAL hotfix (incident, last commit on the branch)**
\`buildTimelineTree\` now tracks \`claimedNodeIds\` so each event enters the tree exactly once. Without this, two legacy branches sharing an \`edge.x\` (B12 in old data) made every event on that x land in the tree multiple times, and \`flattenTree → setNodes\` re-fed the doubled state on the next mousemove, exploding to ~60k events in seconds and freezing the browser. Repro happened on the \`Аксельрод\` canvas; verified on preview after the fix that 60 mousemoves on the same coordinate keep node count at 96.

## Test plan
- [x] \`npm run typecheck:app\` — clean
- [x] \`npm run validate\` — clean
- [x] \`npm test -- --run src/pages/timeline\` — 104 tests, all green
- [x] Live drag on Аксельрод (preview): 60 mousemoves on \`x=1500\` (3 legacy branches) → 96 → 96 circles, no explosion
- [x] Other timeline canvases unaffected — same render
- [ ] Reviewer: open the preview URL and try drag/delete/edit on a canvas with branches; confirm siblings stay put when one event moves

## Stats
- 14 files changed, +1576 / −177
- 105+ new and updated tests (timelineTree, useTimelineDragDrop, useTimelineCRUD, useTimelineBranch, persistence)
- Net result: \`useTimelineDragDrop\` lost 84 lines, \`useTimelineBranch\`/\`useTimelineCRUD\` got light validators

🤖 Generated with [Claude Code](https://claude.com/claude-code)